### PR TITLE
fix(audiodriver): remove alsa setup use pipewire volume only

### DIFF
--- a/02-stage-audiodriver-2michat-v1/02-set-audio-volume/files/configure_audio.sh
+++ b/02-stage-audiodriver-2michat-v1/02-set-audio-volume/files/configure_audio.sh
@@ -46,9 +46,6 @@ set_control_if_exists() {
 if wait_for_card_and_control seeed2micvoicec Headphone; then
   CARD="seeed2micvoicec"
   echo "seeed2micvoicec found"
-elif wait_for_card_and_control Lite Headphone; then
-  CARD="Lite"
-  echo "Lite found"
 else
   echo "No supported sound card became ready"
   exit 1

--- a/02-stage-audiodriver-other/01-set-audio-volume/files/configure_audio.sh
+++ b/02-stage-audiodriver-other/01-set-audio-volume/files/configure_audio.sh
@@ -43,22 +43,6 @@ set_control_if_exists() {
   return 0
 }
 
-if wait_for_card_and_control seeed2micvoicec Headphone; then
-  CARD="seeed2micvoicec"
-  echo "seeed2micvoicec found"
-elif wait_for_card_and_control Lite Headphone; then
-  CARD="Lite"
-  echo "Lite found"
-else
-  echo "No supported sound card became ready"
-  exit 1
-fi
-
-set_control_if_exists "$CARD" Headphone 100%
-set_control_if_exists "$CARD" Speaker 100%
-set_control_if_exists "$CARD" Master 100%
-set_control_if_exists "$CARD" PCM 100%
-
 # Set pipewire sink to 100%
 wpctl set-volume @DEFAULT_AUDIO_SINK@ 1.0
 

--- a/02-stage-audiodriver-respeaker_lite/02-set-audio-volume/files/configure_audio.sh
+++ b/02-stage-audiodriver-respeaker_lite/02-set-audio-volume/files/configure_audio.sh
@@ -43,22 +43,6 @@ set_control_if_exists() {
   return 0
 }
 
-if wait_for_card_and_control seeed2micvoicec Headphone; then
-  CARD="seeed2micvoicec"
-  echo "seeed2micvoicec found"
-elif wait_for_card_and_control Lite Headphone; then
-  CARD="Lite"
-  echo "Lite found"
-else
-  echo "No supported sound card became ready"
-  exit 1
-fi
-
-set_control_if_exists "$CARD" Headphone 100%
-set_control_if_exists "$CARD" Speaker 100%
-set_control_if_exists "$CARD" Master 100%
-set_control_if_exists "$CARD" PCM 100%
-
 # Set pipewire sink to 100%
 wpctl set-volume @DEFAULT_AUDIO_SINK@ 1.0
 


### PR DESCRIPTION
Remove legacy sound card detection and ALSA mixer configuration from all audio driver stage scripts. Standardize volume setup to only use PipeWire default sink setting across all driver variants.