### PR TITLE
perf(pipewire): enable real-time scheduling

### DIFF
--- a/01-stage-picompose/03-install-pipewire-audio/files/linux-voice-assistant.conf
+++ b/01-stage-picompose/03-install-pipewire-audio/files/linux-voice-assistant.conf
@@ -1,3 +1,13 @@
 context.properties = {
     default.clock.rate = 16000
 }
+
+context.modules = [
+    {   name = libpipewire-module-rt
+        args = {
+            nice.level    = -11
+            rt.prio       = 88
+        }
+        flags = [ ifexists nofail ]
+    }
+]


### PR DESCRIPTION
Add libpipewire-module-rt to the PipeWire configuration to provide real-time priority for audio processing. This helps reduce latency and prevent audio glitches by setting a higher nice level and RT priority.

See https://github.com/OHF-Voice/linux-voice-assistant/pull/376/changes