### PR TITLE
Re-Enable the Respeaker v1 version builds

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -111,3 +111,4 @@ jobs:
     needs: [build, build-lva, build-2michat, build-2michat-v2, build-2michat-lva, build-2michat-v2-lva, build-respeaker_lite, build-respeaker_lite-lva, build-satellite1-v1dot0, build-satellite1-v1dot0-lva]
     if: always()
     uses: ./.github/workflows/create-rpi-image-json.yml
+    secrets: inherit

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -32,7 +32,6 @@ jobs:
       custom-hostname: picompose
   # 2MICHAT-v1
   build-2michat:
-    if: false # disabled
     uses: ./.github/workflows/build-image-template.yml
     with:
       image-name: PiCompose-2MicHat-v1
@@ -42,7 +41,6 @@ jobs:
       custom-hostname: picompose
 
   build-2michat-lva:
-    if: false # disabled
     uses: ./.github/workflows/build-image-template.yml
     with:
       image-name: PiCompose_2MicHat-v1_Linux-Voice-Assistant
@@ -110,6 +108,6 @@ jobs:
 
   # RPI IMAGER JSON
   generate-rpi-imager-json:
-    needs: [build, build-2michat, build-respeaker_lite, build-2michat-lva, build-respeaker_lite-lva]
+    needs: [build, build-lva, build-2michat, build-2michat-v2, build-2michat-lva, build-2michat-v2-lva, build-respeaker_lite, build-respeaker_lite-lva, build-satellite1-v1dot0, build-satellite1-v1dot0-lva]
     if: always()
     uses: ./.github/workflows/create-rpi-image-json.yml

--- a/02-stage-audiodriver-2michat-v1/01-driver/03-run-chroot.sh
+++ b/02-stage-audiodriver-2michat-v1/01-driver/03-run-chroot.sh
@@ -37,7 +37,7 @@ for kernel_version in $all_kernel_versions; do
     cd $kernel_version
 
     echo "Checking download source"
-    driver_url_status="$(curl -ILs https://github.com/HinTak/seeed-voicecard/archive/refs/heads/v$kernel_version.tar.gz | tac | grep -o "^HTTP.*" | cut -f 2 -d' ' | head -1)"
+    driver_url_status="$(curl -ILs https://github.com/trnila/seeed-voicecard/archive/refs/heads/v6.15.tar.gz | tac | grep -o "^HTTP.*" | cut -f 2 -d' ' | head -1)"
     if  [ ! "$driver_url_status" = 200 ]; then
     echo "Could not find driver for kernel $kernel_version"
     exit 1
@@ -46,9 +46,9 @@ for kernel_version in $all_kernel_versions; do
     # Download source code to temporary directory
     # NOTE: There are different branches in the repo for different kernel versions.
     echo 'Downloading source code'
-    wget "https://github.com/HinTak/seeed-voicecard/archive/refs/heads/v$kernel_version.tar.gz"
-    tar -xf v$kernel_version.tar.gz
-    cd "seeed-voicecard-$kernel_version"
+    wget "https://github.com/trnila/seeed-voicecard/archive/refs/heads/v6.15.tar.gz"
+    tar -xf v6.15.tar.gz
+    cd "seeed-voicecard-6.15"
 
     # 1. Build kernel module
     echo 'Building kernel module'

--- a/02-stage-audiodriver-2michat-v1/01-driver/03-run-chroot.sh
+++ b/02-stage-audiodriver-2michat-v1/01-driver/03-run-chroot.sh
@@ -37,7 +37,7 @@ for kernel_version in $all_kernel_versions; do
     cd $kernel_version
 
     echo "Checking download source"
-    driver_url_status="$(curl -ILs https://github.com/trnila/seeed-voicecard/archive/refs/heads/v6.15.tar.gz | tac | grep -o "^HTTP.*" | cut -f 2 -d' ' | head -1)"
+    driver_url_status="$(curl -ILs https://github.com/HinTak/seeed-voicecard/archive/refs/heads/v$kernel_version.tar.gz | tac | grep -o "^HTTP.*" | cut -f 2 -d' ' | head -1)"
     if  [ ! "$driver_url_status" = 200 ]; then
     echo "Could not find driver for kernel $kernel_version"
     exit 1
@@ -46,9 +46,9 @@ for kernel_version in $all_kernel_versions; do
     # Download source code to temporary directory
     # NOTE: There are different branches in the repo for different kernel versions.
     echo 'Downloading source code'
-    wget "https://github.com/trnila/seeed-voicecard/archive/refs/heads/v6.15.tar.gz"
-    tar -xf v6.15.tar.gz
-    cd "seeed-voicecard-6.15"
+    wget "https://github.com/HinTak/seeed-voicecard/archive/refs/heads/v$kernel_version.tar.gz"
+    tar -xf v$kernel_version.tar.gz
+    cd "seeed-voicecard-$kernel_version"
 
     # 1. Build kernel module
     echo 'Building kernel module'


### PR DESCRIPTION
Re-Enable the Respeaker v1 version builds. I tested the temporary version from https://github.com/HinTak/seeed-voicecard/pull/48. It works and can be merged.