### PR TITLE
feat(lva): add new environment configuration options

### DIFF
--- a/03-stage-linux-voice-assistant/01-linux-voice-assistant/files/lva/.env
+++ b/03-stage-linux-voice-assistant/01-linux-voice-assistant/files/lva/.env
@@ -8,6 +8,9 @@
 ### Enable debug mode (optional):
 # ENABLE_DEBUG="1"
 
+### Enable colored debug mode (optional):
+# ENABLE_COLORED_DEBUG="1"
+
 ### List audio devices (optional):
 # if enabled normal startup is disabled
 # LIST_DEVICES="1"
@@ -45,14 +48,24 @@ LVA_PULSE_COOKIE="/run/user/${LVA_USER_ID}/pulse/cookie"
 ### Audio output device (optional):
 # AUDIO_OUTPUT_DEVICE="default"
 
-### Mic Gain (optional) passed as an argument to LVA will overide the value in thepreferences file on boot but can be changed at runtime in Home Assistant:
+### Microphone volume level (optional):
+# MIC_VOLUME="100"
+
+### Mic Gain (optional) passed as an argument to LVA will overide the value in the preferences file on boot but can be changed at runtime in Home Assistant:
 # MIC_AUTO_GAIN="0"
 
-### Mic Noise Suppression (optional) passed as an argument to LVA will overide the value in thepreferences file on boot but can be changed at runtime in Home Assistant:
+### Mic Noise Suppression (optional) passed as an argument to LVA will overide the value in the preferences file on boot but can be changed at runtime in Home Assistant:
 # MIC_NOISE_SUPPRESSION="0"
+
+### Number of mic channels to stream
+# AUDIO_INPUT_CHANNELS=2
 
 ### Enable thinking sound (optional):
 # ENABLE_THINKING_SOUND="1"
+
+### Start listening during wake sound (optional):
+# Start listening immediately after wake word detection, without waiting for the wake sound to finish
+# LISTEN_DURING_WAKE_SOUND="1"
 
 ### Wake word directory (optional):
 # path for custom files in docker is for example "app/wakewords/custom"
@@ -69,6 +82,9 @@ LVA_PULSE_COOKIE="/run/user/${LVA_USER_ID}/pulse/cookie"
 
 ### Refactory seconds (optional):
 # REFACTORY_SECONDS="2"
+
+### Delay before mic opens for continued conversation (optional):
+# CONTINUE_CONVERSATION_DELAY="0.5"
 
 ### Sound files (optional):
 # path for custom files in docker is for example "sounds/custom/your_soundfile.flac"


### PR DESCRIPTION
Introduce several new configuration variables to the Linux Voice Assistant environment file to enhance debugging, audio control, and user experience.

- Add `ENABLE_COLORED_DEBUG` for enhanced debug output
- Add `MIC_VOLUME` for microphone volume control
- Add `AUDIO_INPUT_CHANNELS` to specify mic streaming channels
- Add `LISTEN_DURING_WAKE_SOUND` to allow immediate listening after wake word
- Add `CONTINUE_CONVERSATION_DELAY` to control mic opening delay